### PR TITLE
feat: adds PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+
+<!--
+    If there is an issue that prompted this change, please replace the XX's below with the issue number. 
+
+    If not, delete the line of Markdown.
+
+    For formatting help please see our Contrubuting Documentation:
+
+    https://github.com/Liftric/DIKit/blob/master/CONTRIBUTING.md
+
+-->
+
+## Why was this change made (Body)
+
+## Footer
+
+- [ ] There are no breaking changes
+    - If not why and what:
+
+<!--
+    If there is an issue that prompted this change, please replace the XX's below with the issue number. 
+
+    If not, delete the line of Markdown.
+-->
+
+## From [Issue XX](https://github.com/Liftric/DIKit/issues/XX) 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,8 @@
 
 <!--
     If there is an issue that prompted this change, please replace the XX's below with the issue number. 
-
     If not, delete the line of Markdown.
-
     For formatting help please see our Contrubuting Documentation:
-
     https://github.com/Liftric/DIKit/blob/master/CONTRIBUTING.md
 
 -->
@@ -19,7 +16,6 @@
 
 <!--
     If there is an issue that prompted this change, please replace the XX's below with the issue number. 
-
     If not, delete the line of Markdown.
 -->
 


### PR DESCRIPTION

<!--
    If there is an issue that prompted this change, please replace the XX's below with the issue number. 
    If not, delete the line of Markdown.
    For formatting help please see our Contrubuting Documentation:
    https://github.com/Liftric/DIKit/blob/master/CONTRIBUTING.md

-->

## Why was this change made (Body)

During my first PR against master I was made aware that there was a format I didn't adhere to that was called out in the [Contrubuting Documentation](https://github.com/Liftric/DIKit/blob/master/CONTRIBUTING.md). To help other's not make the same mistake this adds a PR template that will automatically add this markdown format to each PR opened. There are comments in the markdown that link to the contributing documentation for ease of access.

## Footer

- [x] There are no breaking changes *If not why and what:*

<!--
    If there is an issue that prompted this change, please replace the XX's below with the issue number. 
    If not, delete the line of Markdown.
-->

