### PR TITLE
Lazy injection and new container resolvement

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: macOS-latest
-
     steps:
     - uses: actions/checkout@v1
+      with:
+        swift-version: "5.1"
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,16 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-        swift-version: ['5.1', 'DEVELOPMENT-SNAPSHOT-2019-09-30-a']
-    runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     name: Build & Test DIKit
     steps:
     - uses: actions/checkout@v1
+    - uses: YOCKOW/Action-setup-swift@master
       with:
-        swift-version: ${{ matrix.swift-version }}
+        swift-version: "5.1"
     - name: View Swift Version
       run: swift --version
     - name: Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,14 +1,21 @@
-name: Swift
+name: DIKit
 
 on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: macOS-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        swift-version: ['5.1', 'DEVELOPMENT-SNAPSHOT-2019-09-30-a']
+    runs-on: ${{ matrix.os }}
+    name: Build & Test DIKit
     steps:
     - uses: actions/checkout@v1
       with:
-        swift-version: "5.1"
+        swift-version: ${{ matrix.swift-version }}
+    - name: View Swift Version
+      run: swift --version
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ fastlane/screenshots
 fastlane/test_output
 
 .DS_Store
+.idea/

--- a/DIKit/Sources/Container/DefinesContainer.swift
+++ b/DIKit/Sources/Container/DefinesContainer.swift
@@ -7,7 +7,7 @@
 //
 // Copyright © 2018 Ben John. All rights reserved.
 
-/// Exposes the `DependencyContainer` through `AppDelegate`.
+/// Exposes the `DependencyContainer` through for instance `AppDelegate`.
 public protocol DefinesContainer {
     var container: DependencyContainer { get }
 }

--- a/DIKit/Sources/Container/DependencyContainer.swift
+++ b/DIKit/Sources/Container/DependencyContainer.swift
@@ -25,6 +25,21 @@ public final class DependencyContainer {
     var instanceStack = InstanceStack()
     let lock = NSRecursiveLock()
 
+    private static var _defines: DefinesContainer?
+    public static var defines: DefinesContainer {
+        get {
+            guard let defines = _defines else {
+                fatalError("DefinesContainer is not yet set.")
+            }
+            return defines
+        }
+        set {
+            guard _defines == nil else {
+                fatalError("It is not allowed to override the `DefinesContainer` at runtime.")
+            }
+        }
+    }
+
     // MARK: - Public methods
     /// Derives a `DependencyContainer` from multiple sub containers.
     ///

--- a/DIKit/Sources/Container/DependencyContainer.swift
+++ b/DIKit/Sources/Container/DependencyContainer.swift
@@ -37,6 +37,7 @@ public final class DependencyContainer {
             guard _defines == nil else {
                 fatalError("It is not allowed to override the `DefinesContainer` at runtime.")
             }
+            _defines = newValue
         }
     }
 

--- a/DIKit/Sources/DIKit.swift
+++ b/DIKit/Sources/DIKit.swift
@@ -38,7 +38,7 @@ public enum Inject<Component> {
         self = .resolved(resolve())
     }
 
-    public init(relationship: Relationship = .direct) {
+    public init(_ relationship: Relationship = .direct) {
         if relationship == .lazy {
             self = .unresolved({ resolve() })
         } else {

--- a/DIKit/Tests/DIKitTests.swift
+++ b/DIKit/Tests/DIKitTests.swift
@@ -135,6 +135,44 @@ class DIKitTests: XCTestCase {
         XCTAssertNotEqual(componentAinstanceAobjectIdA, componentAinstanceBobjectId)
     }
 
+    func testLazyInjection() {
+        struct TestStateHolder {
+            static var initializedA = false
+            static var initializedB = false
+        }
+        class ComponentA {
+            init() {
+                TestStateHolder.initializedA = true
+            }
+        }
+        class ComponentB {
+            init() {
+                TestStateHolder.initializedB = true
+            }
+        }
+        class TestApplication: DefinesContainer {
+            let container = module {
+                single { ComponentA() }
+                factory { ComponentB() }
+            }
+        }
+        DependencyContainer.defines = TestApplication()
+
+        class TestViewController {
+            @Inject var componentA: ComponentA
+            @Inject(.lazy) var componentB: ComponentB
+        }
+
+        let testVC = TestViewController()
+        XCTAssertTrue(TestStateHolder.initializedA)
+        _ = testVC.componentA
+        XCTAssertTrue(TestStateHolder.initializedA)
+
+        XCTAssertFalse(TestStateHolder.initializedB)
+        _ = testVC.componentB
+        XCTAssertTrue(TestStateHolder.initializedB)
+    }
+
     func testFactoryOfComponentsDSL() {
         class ComponentA {}
 


### PR DESCRIPTION
As we are not allowed to invoke `UIApplication.shared.delegate` on anything but the main thread, we need some workaround, especially for the other derivatives, like macOS, tvOS, etc.!

Thus, we use some kind of dirty static variable to get along with those issues.

Besides these changes, I also include lazy injection and bit of syntactic sugar for that.