### PR TITLE
Add the option to resolve dependencies by name

### DIFF
--- a/DIKit/Sources/Component/Component.swift
+++ b/DIKit/Sources/Component/Component.swift
@@ -11,21 +11,44 @@ public typealias ComponentFactory = () -> Any
 
 class Component<T>: ComponentProtocol {
     let lifetime: Lifetime
-    let tag: String
+    let identifier: AnyHashable
     let type: Any.Type
     let componentFactory: ComponentFactory
 
     init(lifetime: Lifetime, type: T.Type, factory: @escaping () -> T) {
         self.lifetime = lifetime
-        self.tag = String(describing: type)
+        self.identifier = ComponentIdentifier(type: type)
         self.type = type
         self.componentFactory = { factory() }
     }
 }
 
+struct ComponentIdentifier: Hashable {
+    let tag: AnyHashable?
+    let type: Any.Type
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(String(describing: type))
+        if let tag = tag {
+            hasher.combine(tag)
+        }
+    }
+
+    static func == (lhs: ComponentIdentifier, rhs: ComponentIdentifier) -> Bool {
+        lhs.type == rhs.type && lhs.tag == rhs.tag
+    }
+}
+
+extension ComponentIdentifier {
+    init(type: Any.Type) {
+        self.type = type
+        self.tag = nil
+    }
+}
+
 public protocol ComponentProtocol {
     var lifetime: Lifetime { get }
-    var tag: String { get }
+    var identifier: AnyHashable { get }
     var componentFactory: ComponentFactory { get }
     var type: Any.Type { get }
 }

--- a/DIKit/Sources/Component/Component.swift
+++ b/DIKit/Sources/Component/Component.swift
@@ -15,10 +15,17 @@ class Component<T>: ComponentProtocol {
     let type: Any.Type
     let componentFactory: ComponentFactory
 
-    init(lifetime: Lifetime, type: T.Type, factory: @escaping () -> T) {
+    init(lifetime: Lifetime, factory: @escaping () -> T) {
         self.lifetime = lifetime
-        self.identifier = ComponentIdentifier(type: type)
-        self.type = type
+        self.identifier = ComponentIdentifier(type: T.self)
+        self.type = T.self
+        self.componentFactory = { factory() }
+    }
+
+    init(lifetime: Lifetime, tag: AnyHashable, factory: @escaping () -> T) {
+        self.lifetime = lifetime
+        self.identifier = ComponentIdentifier(tag: tag, type: T.self)
+        self.type = T.self
         self.componentFactory = { factory() }
     }
 }

--- a/DIKit/Sources/Container/DependencyContainer+Register.swift
+++ b/DIKit/Sources/Container/DependencyContainer+Register.swift
@@ -11,17 +11,22 @@ extension DependencyContainer {
     /// Registers a `Component`.
     ///
     /// - Parameters:
-    ///     - scope: The *scope* of the `Component`, defaults to `Lifetime.singleton`.
+    ///     - lifetime: The *scope* of the `Component`, defaults to `Lifetime.singleton`.
     ///     - factory: The *factory* for the initialization of the `Component`.
     public func register<T>(lifetime: Lifetime = .singleton, _ factory: @escaping () -> T) {
-        precondition(!bootstrapped, "After boostrap no more components can be registered.")
-        threadSafe {
-            let component = Component(lifetime: lifetime, type: T.self, factory: factory)
-            guard self.componentStack[component.identifier] == nil else {
-                fatalError("A component can only be registered once.")
-            }
-            self.componentStack[component.identifier] = component
-        }
+        let component = Component(lifetime: lifetime, factory: factory)
+        register(component)
+    }
+
+    /// Registers a `Component`
+    ///
+    /// - Parameters:
+    ///   - lifetime: The *scope* of the `Component`, defaults to `Lifetime.singleton`.
+    ///   - tag: A *tag* for the `Component` used to identify it.
+    ///   - factory: The *factory* for the initialization of the `Component`.
+    public func register<T>(lifetime: Lifetime = .singleton, tag: AnyHashable, _ factory: @escaping () -> T) {
+        let component = Component(lifetime: lifetime, tag: tag, factory: factory)
+        register(component)
     }
 
     public func register(_ component: ComponentProtocol) {

--- a/DIKit/Sources/Container/DependencyContainer+Register.swift
+++ b/DIKit/Sources/Container/DependencyContainer+Register.swift
@@ -17,20 +17,20 @@ extension DependencyContainer {
         precondition(!bootstrapped, "After boostrap no more components can be registered.")
         threadSafe {
             let component = Component(lifetime: lifetime, type: T.self, factory: factory)
-            guard self.componentStack[component.tag] == nil else {
+            guard self.componentStack[component.identifier] == nil else {
                 fatalError("A component can only be registered once.")
             }
-            self.componentStack[component.tag] = component
+            self.componentStack[component.identifier] = component
         }
     }
 
     public func register(_ component: ComponentProtocol) {
         precondition(!bootstrapped, "After boostrap no more components can be registered.")
         threadSafe {
-            guard self.componentStack[component.tag] == nil else {
+            guard self.componentStack[component.identifier] == nil else {
                 fatalError("A component can only be registered once.")
             }
-            self.componentStack[component.tag] = component
+            self.componentStack[component.identifier] = component
         }
     }
 }

--- a/DIKit/Sources/Container/DependencyContainer+Resolve.swift
+++ b/DIKit/Sources/Container/DependencyContainer+Resolve.swift
@@ -10,9 +10,10 @@
 extension DependencyContainer {
     /// Resolves nil safe a `Component<T>`.
     ///
+    /// - Parameter tag: An optional *tag* to identify the Component. `nil` per default.
     /// - Returns: The resolved `Optional<Component<T>>`.
-    func _resolve<T>() -> T? {
-        let identifier = ComponentIdentifier(type: T.self)
+    func _resolve<T>(tag: AnyHashable? = nil) -> T? {
+        let identifier = ComponentIdentifier(tag: tag, type: T.self)
         guard let foundComponent = self.componentStack[identifier] else {
             return nil
         }
@@ -32,10 +33,11 @@ extension DependencyContainer {
     ///
     /// - Parameters:
     ///     - type: The generic *type* of the `Component`.
+    ///     - tag: An optional *tag* to identify the Component. `nil` per default.
     ///
     /// - Returns: `Bool` whether `Component<T>` is resolvable or not.
-    func resolvable<T>(type: T.Type) -> Bool {
-        let identifier = ComponentIdentifier(type: T.self)
+    func resolvable<T>(type: T.Type, tag: AnyHashable? = nil) -> Bool {
+        let identifier = ComponentIdentifier(tag: tag, type: T.self)
         return self.componentStack[identifier] != nil
     }
 
@@ -43,9 +45,11 @@ extension DependencyContainer {
     /// Implicitly assumes that the `Component` can be resolved.
     /// Throws a fatalError if the `Component` is not registered.
     ///
+    /// - Parameter tag: An optional *tag* to identify the Component. `nil` per default.
+    ///
     /// - Returns: The resolved `Component<T>`.
-    public func resolve<T>() -> T {
-        if let t: T = _resolve() {
+    public func resolve<T>(tag: AnyHashable? = nil) -> T {
+        if let t: T = _resolve(tag: tag) {
             return t
         }
         fatalError("Component `\(String(describing: T.self))` could not be resolved.")

--- a/DIKit/Sources/Container/DependencyContainer+Resolve.swift
+++ b/DIKit/Sources/Container/DependencyContainer+Resolve.swift
@@ -12,18 +12,18 @@ extension DependencyContainer {
     ///
     /// - Returns: The resolved `Optional<Component<T>>`.
     func _resolve<T>() -> T? {
-        let tag = String(describing: T.self)
-        guard let foundComponent = self.componentStack[tag] else {
+        let identifier = ComponentIdentifier(type: T.self)
+        guard let foundComponent = self.componentStack[identifier] else {
             return nil
         }
         if foundComponent.lifetime == .factory {
             return foundComponent.componentFactory() as? T
         }
-        if let instanceOfComponent = self.instanceStack[tag] as? T {
+        if let instanceOfComponent = self.instanceStack[identifier] as? T {
             return instanceOfComponent
         }
         let instance = foundComponent.componentFactory() as! T
-        self.instanceStack[tag] = instance
+        self.instanceStack[identifier] = instance
         return instance
     }
 
@@ -35,8 +35,8 @@ extension DependencyContainer {
     ///
     /// - Returns: `Bool` whether `Component<T>` is resolvable or not.
     func resolvable<T>(type: T.Type) -> Bool {
-        let tag = String(describing: type)
-        return self.componentStack[tag] != nil
+        let identifier = ComponentIdentifier(type: T.self)
+        return self.componentStack[identifier] != nil
     }
 
     /// Resolves a `Component<T>`.

--- a/DIKit/Sources/Container/DependencyContainer.swift
+++ b/DIKit/Sources/Container/DependencyContainer.swift
@@ -13,8 +13,8 @@ import Foundation
 public final class DependencyContainer {
     // MARK: - Typealiases
     public typealias BootstrapBlock = (DependencyContainer) -> Void
-    internal typealias ComponentStack = [String: ComponentProtocol]
-    internal typealias InstanceStack = [String: Any]
+    internal typealias ComponentStack = [AnyHashable: ComponentProtocol]
+    internal typealias InstanceStack = [AnyHashable: Any]
 
     // MARK: - Properties
     internal var bootstrapped = false

--- a/DIKit/Sources/DIKit+Inject.swift
+++ b/DIKit/Sources/DIKit+Inject.swift
@@ -18,6 +18,10 @@ public enum LazyInject<Component> {
         self = .unresolved({ resolve() })
     }
 
+    public init(tag: AnyHashable? = nil) {
+        self = .unresolved({ resolve(tag: tag) })
+    }
+
     public var wrappedValue: Component {
         mutating get {
             switch self {
@@ -41,6 +45,10 @@ public struct Inject<Component> {
     public init() {
         self.wrappedValue = resolve()
     }
+
+    public init(tag: AnyHashable? = nil) {
+        self.wrappedValue = resolve(tag: tag)
+    }
 }
 
 /// A property wrapper (SE-0258) to make a `Optional<Component>` injectable
@@ -52,6 +60,10 @@ public enum OptionalInject<Component> {
 
     public init() {
         self = .unresolved({ resolveOptional() })
+    }
+
+    public init(tag: AnyHashable? = nil) {
+        self = .unresolved({ resolveOptional(tag: tag) })
     }
 
     public var wrappedValue: Component? {

--- a/DIKit/Sources/DIKit.swift
+++ b/DIKit/Sources/DIKit.swift
@@ -9,13 +9,15 @@
 
 /// Resolves given `Component<T>`.
 ///
+/// - Parameter tag: An optional *tag* to identify the Component. `nil` per default.
 /// - Returns: The resolved `Component<T>`.
-public func resolve<T>() -> T { DependencyContainer.shared.resolve() }
+public func resolve<T>(tag: AnyHashable? = nil) -> T { DependencyContainer.shared.resolve(tag: tag) }
 
 /// Resolves nil safe given `Component<T>`.
 ///
+/// - Parameter tag: An optional *tag* to identify the Component. `nil` per default.
 /// - Returns: The resolved `Optional<Component<T>>`.
-public func resolveOptional<T>() -> T? {
-    guard DependencyContainer.shared.resolvable(type: T.self) else { return nil }
-    return DependencyContainer.shared._resolve()
+public func resolveOptional<T>(tag: AnyHashable? = nil) -> T? {
+    guard DependencyContainer.shared.resolvable(type: T.self, tag: tag) else { return nil }
+    return DependencyContainer.shared._resolve(tag: tag)
 }

--- a/DIKit/Sources/DIKitDSL.swift
+++ b/DIKit/Sources/DIKitDSL.swift
@@ -41,10 +41,22 @@ public func resolvable<T>(lifetime: Lifetime = .singleton, _ factory: @escaping 
     Component(lifetime: lifetime, factory: factory) as ComponentProtocol
 }
 
+public func resolvable<T>(lifetime: Lifetime = .singleton, tag: AnyHashable, _ factory: @escaping () -> T) -> ComponentProtocol {
+    Component(lifetime: lifetime, tag: tag, factory: factory) as ComponentProtocol
+}
+
 public func factory<T>(factory: @escaping () -> T) -> [ComponentProtocol] {
     [resolvable(lifetime: .factory, factory)]
 }
 
+public func factory<T>(tag: AnyHashable, factory: @escaping () -> T) -> [ComponentProtocol] {
+    [resolvable(lifetime: .factory, tag: tag, factory)]
+}
+
 public func single<T>(factory: @escaping () -> T) -> [ComponentProtocol] {
     [resolvable(lifetime: .singleton, factory)]
+}
+
+public func single<T>(tag: AnyHashable, factory: @escaping () -> T) -> [ComponentProtocol] {
+    [resolvable(lifetime: .singleton, tag: tag, factory)]
 }

--- a/DIKit/Sources/DIKitDSL.swift
+++ b/DIKit/Sources/DIKitDSL.swift
@@ -38,7 +38,7 @@ public func modules(@ModulesBuilder makeChildren: () -> [DependencyContainer]) -
 }
 
 public func resolvable<T>(lifetime: Lifetime = .singleton, _ factory: @escaping () -> T) -> ComponentProtocol {
-    Component(lifetime: lifetime, type: T.self, factory: factory) as ComponentProtocol
+    Component(lifetime: lifetime, factory: factory) as ComponentProtocol
 }
 
 public func factory<T>(factory: @escaping () -> T) -> [ComponentProtocol] {

--- a/DIKit/Tests/DIKitTests.swift
+++ b/DIKit/Tests/DIKitTests.swift
@@ -96,10 +96,14 @@ class DIKitTests: XCTestCase {
         let dependencyContainerC = DependencyContainer { (c: DependencyContainer) in
             c.register { ComponentC() }
         }
+        let dependencyContainerD = DependencyContainer { (c: DependencyContainer) in
+            c.register(tag: "tag") { ComponentC() }
+        }
 
         let dependencyContainer = DependencyContainer.derive(from: dependencyContainerA,
                                                              dependencyContainerB,
-                                                             dependencyContainerC)
+                                                             dependencyContainerC,
+                                                             dependencyContainerD)
 
         let componentA: ComponentA = dependencyContainer.resolve()
         XCTAssertNotNil(componentA)
@@ -109,6 +113,9 @@ class DIKitTests: XCTestCase {
 
         let componentC: ComponentC = dependencyContainer.resolve()
         XCTAssertNotNil(componentC)
+
+        let taggedComponentC: ComponentC = dependencyContainer.resolve(tag: "tag")
+        XCTAssertNotNil(taggedComponentC)
     }
 
     func testDependencyContainerDeriveDSL() {
@@ -125,8 +132,11 @@ class DIKitTests: XCTestCase {
         let dependencyContainerC = module {
             single { ComponentC() }
         }
+        let dependencyContainerD = module {
+            single(tag: "tag") { ComponentC() }
+        }
 
-        let dependencyContainer = modules { dependencyContainerA; dependencyContainerB; dependencyContainerC }
+        let dependencyContainer = modules { dependencyContainerA; dependencyContainerB; dependencyContainerC; dependencyContainerD }
 
         let componentA: ComponentA = dependencyContainer.resolve()
         XCTAssertNotNil(componentA)
@@ -136,6 +146,9 @@ class DIKitTests: XCTestCase {
 
         let componentC: ComponentC = dependencyContainer.resolve()
         XCTAssertNotNil(componentC)
+
+        let taggedComponentC: ComponentC = dependencyContainer.resolve(tag: "tag")
+        XCTAssertNotNil(taggedComponentC)
     }
 
     func testFactoryOfComponents() {

--- a/DIKit/Tests/DIKitTests.swift
+++ b/DIKit/Tests/DIKitTests.swift
@@ -28,7 +28,8 @@ class DIKitTests: XCTestCase {
             c.register { ComponentB() }
         }
 
-        guard let componentA = dependencyContainer.componentStack.index(forKey: "ComponentA") else {
+        let componentAIdentifier = ComponentIdentifier(type: ComponentA.self)
+        guard let componentA = dependencyContainer.componentStack.index(forKey: componentAIdentifier) else {
             return XCTFail("ComponentStack does not contain `ComponentA`.")
         }
         let componentProtocolA = dependencyContainer.componentStack[componentA].value
@@ -37,7 +38,8 @@ class DIKitTests: XCTestCase {
         XCTAssertTrue(instanceA is ComponentA)
         XCTAssertFalse(instanceA is ComponentB)
 
-        guard let componentB = dependencyContainer.componentStack.index(forKey: "ComponentB") else {
+        let componentBIdentifier = ComponentIdentifier(type: ComponentB.self)
+        guard let componentB = dependencyContainer.componentStack.index(forKey: componentBIdentifier) else {
             return XCTFail("ComponentStack does not contain `ComponentB`.")
         }
         let componentProtocolB = dependencyContainer.componentStack[componentB].value


### PR DESCRIPTION
Implements #8

This PR add functionality to resolve dependencies by **name** or in this case **tag**.
In order to do so, I changed the following:

A component no longer has a `tag: String` but an `let identifier: AnyHashable`. This identifier is used to reference the `Component` as well as the instance in the `Container` (`ComponentStack` and `InstanceStack`). I also added a `ComponentIdentifier` struct that uses the `Type` of the factory as well as an optional `tag` to calculate the `hashValue`. So instead of a String of the Type, we now use the hashValue of the type to identify a Component or an instance in our Container.

Next I added an optional `tag: AnyHashable` parameter to all functions that are used to register or resolve dependencies. 

I didn't write any documentation in the `README` yet since I first wanted to get some feedback about this first. I am looking forward to hear ideas on how this could be improved.