### PR TITLE
define at runtime

### DIFF
--- a/DIKit.podspec
+++ b/DIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "DIKit"
-  s.version = "1.6.1"
+  s.version = "1.6.2"
   s.license = { :type => "MIT", :file => "LICENSE" }
 
   s.summary = "Dependency Injection Framework for Swift."
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, "9.0"
   s.swift_version    = "5.4"
 
-  s.source           = { :git => "https://github.com/benjohnde/DIKit.git", :tag => "#{s.version}" }
+  s.source           = { :git => "https://github.com/AlessioCampanelli/DIKit-runtime.git", :tag => "#{s.version}" }
 
   s.source_files      = "DIKit/Sources/**/*.{swift}"
   s.requires_arc = true

--- a/DIKit/Sources/Container/DependencyContainer+Context.swift
+++ b/DIKit/Sources/Container/DependencyContainer+Context.swift
@@ -19,4 +19,13 @@ extension DependencyContainer {
         }
         self.root = root
     }
+    
+    /// Defines the used `DependencyContainer` root at runtime for resolving components.
+    /// Can can be statically resolved for injection.
+    ///
+    /// - Parameters:
+    ///     - by: *DependencyContainer* the root `DependencyContainer`
+    public static func definedAtRuntime(by root: DependencyContainer) {
+        self.root = root
+    }
 }


### PR DESCRIPTION
It should so useful to expose a method that hasn't strict rules on root assignment.
In this way I can define container in Unit test class to (like an Spring approach).

Thanks a lot for your work. 